### PR TITLE
Create .dockerignore files

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build


### PR DESCRIPTION
Creates `.dockerignore` files in the client and server to ignore the `node_modules` and `build` directories, forcing them to be remade.

Prevents this error: `Error: /home/node/app/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node: invalid ELF header`

https://stackoverflow.com/a/69039455