### PR TITLE
Change naming scheme to be based on file index instead of checksum

### DIFF
--- a/server/src/v2/modules/file.js
+++ b/server/src/v2/modules/file.js
@@ -42,14 +42,15 @@ export function generateChecksum(content) {
   return crypto.SHA256(content).toString()
 }
 
-export async function writeSecretFile(buffer, passphrase, method, id = undefined) {
+export async function writeSecretFile(buffer, passphrase, method, id = undefined, file_number = 0) {
   try {
     var content = buffer.toString()
     var checksum = generateChecksum(content)
     var encryptedFileContents = cipher.encrypt(content, passphrase, method)
 
     var saveDirectory = id !== undefined ? [SECRET_STORAGE_DIRECTORY, id].join('/') : SECRET_STORAGE_DIRECTORY
-    var fileName = [checksum, cipher.generateIdentifier()].join('_')
+    // var fileName = [checksum, cipher.generateIdentifier()].join('_')
+    var fileName = file_number;
     var filePath = [saveDirectory, fileName].join('/')
 
     if (!fs.existsSync(saveDirectory)) {

--- a/server/src/v2/routes/secret/submit.js
+++ b/server/src/v2/routes/secret/submit.js
@@ -78,7 +78,7 @@ export async function secretSubmit(req, res, next) {
         var originalName = f.originalname
         var encryptedFileName = cipher.encrypt(originalName, passphrase, method)
 
-        var savedFile = await file.writeSecretFile(f.buffer, passphrase, method, secretId)
+        var savedFile = await file.writeSecretFile(f.buffer, passphrase, method, secretId, i)
         if (!savedFile.success) {
           return next({status: 500, message: 'Unable to save encrypted file to disk.', error: savedFile.error})
         }


### PR DESCRIPTION
Fixes #82 

We don't use the file name for anything, so it makes sense to just rename it based on the file index.

We lose deduplication functionality, but the effect should be minimal, and it would significantly reduce processing load when saving files.